### PR TITLE
Allow custom component order and custom functions

### DIFF
--- a/lua/slimline/autocommands.lua
+++ b/lua/slimline/autocommands.lua
@@ -19,6 +19,6 @@ vim.api.nvim_create_autocmd('Colorscheme', {
   callback = function()
     local hl = require('slimline.highlights')
     hl.hl_cache = {}
-    hl.create()
+    hl.create(vim.g.slimline_config)
   end,
 })

--- a/lua/slimline/components.lua
+++ b/lua/slimline/components.lua
@@ -1,4 +1,3 @@
-local config = vim.g.slimline_config
 local highlights = require('slimline.highlights')
 local M = {}
 
@@ -50,9 +49,9 @@ function M.get_mode()
 end
 
 --- Function to get the highlight of a given mode
---- @param mode string
 --- @return string
-function M.get_mode_hl(mode)
+function M.get_mode_hl()
+  local mode = M.get_mode()
   if mode == 'NORMAL' then
     return highlights.hls.mode.normal.text
   elseif mode:find('PENDING') then
@@ -68,9 +67,10 @@ function M.get_mode_hl(mode)
 end
 
 --- Mode component
---- @param mode string
+--- @param config table
 --- @return string
-function M.mode(mode)
+function M.mode(config)
+  local mode = M.get_mode()
   local render = mode
   if config.verbose_mode == false then
     render = string.sub(mode, 1, 1)
@@ -86,8 +86,9 @@ end
 --- Git component showing branch
 --- as well as changed, added and removed lines
 --- Using gitsigns for it
+--- @param config table
 --- @return string
-function M.git()
+function M.git(config)
   local status = vim.b.gitsigns_status_dict
   if not status then
     return ''
@@ -127,8 +128,9 @@ end
 
 --- Path component
 --- Displays directory and file seperately
+--- @param config table
 --- @return string
-function M.path()
+function M.path(config)
   local file =
     highlights.highlight_content(' ' .. vim.fn.expand('%:t') .. ' %m%r', highlights.hls.primary.text, config.sep.left)
   file = file .. highlights.highlight_content(config.sep.right, highlights.hls.primary.sep_transition)
@@ -149,8 +151,9 @@ end
 
 local last_diagnostic_component = ''
 --- Diagnostics component
+--- @param config table
 --- @return string
-function M.diagnostics()
+function M.diagnostics(config)
   -- Lazy uses diagnostic icons, but those aren"t errors per se.
   if vim.bo.filetype == 'lazy' then
     return ''
@@ -197,7 +200,8 @@ function M.diagnostics()
 end
 
 --- Filetype and attached LSPs component
-function M.filetype_lsp()
+--- @param config table
+function M.filetype_lsp(config)
   local filetype = vim.bo.filetype
   if filetype == '' then
     filetype = '[No Name]'
@@ -234,8 +238,10 @@ function M.filetype_lsp()
 end
 
 --- File progress component
+--- @param config table
 --- @return string
-function M.progress(mode)
+function M.progress(config)
+  local mode = M.get_mode()
   local cur = vim.fn.line('.')
   local total = vim.fn.line('$')
   local content = ''

--- a/lua/slimline/components.lua
+++ b/lua/slimline/components.lua
@@ -80,7 +80,7 @@ function M.mode(config)
   if config.sep.hide.first then
     sep_left = ''
   end
-  return highlights.highlight_content(content, M.get_mode_hl(mode), sep_left, config.sep.right)
+  return highlights.highlight_content(content, M.get_mode_hl(), sep_left, config.sep.right)
 end
 
 --- Git component showing branch
@@ -241,7 +241,6 @@ end
 --- @param config table
 --- @return string
 function M.progress(config)
-  local mode = M.get_mode()
   local cur = vim.fn.line('.')
   local total = vim.fn.line('$')
   local content = ''
@@ -257,7 +256,7 @@ function M.progress(config)
   if config.sep.hide.last then
     sep_right = ''
   end
-  return highlights.highlight_content(content, M.get_mode_hl(mode), config.sep.left, sep_right)
+  return highlights.highlight_content(content, M.get_mode_hl(), config.sep.left, sep_right)
 end
 
 return M

--- a/lua/slimline/default_config.lua
+++ b/lua/slimline/default_config.lua
@@ -21,18 +21,17 @@ local function create_M()
   }
 
   M.components = {
-    'mode',
-    M.spaces.components,
-    'path',
-    M.spaces.components,
-    'git',
-    '%=',
-    'diagnostics',
-    M.spaces.components,
-    'filetype_lsp',
-    M.spaces.components,
-    'progress',
-    M.spaces.right,
+    left = {
+      'mode',
+      'path',
+      'git',
+    },
+    center = {},
+    right = {
+      'diagnostics',
+      'filetype_lsp',
+      'progress',
+    },
   }
 
   M.hl = {
@@ -50,16 +49,16 @@ local function create_M()
 
   M.icons = {
     diagnostics = {
-      ERROR = ' ',
-      WARN = ' ',
-      HINT = ' ',
-      INFO = ' ',
+      ERROR = ' ',
+      WARN = ' ',
+      HINT = ' ',
+      INFO = ' ',
     },
     git = {
-      branch = '',
+      branch = '',
     },
-    folder = ' ',
-    lines = ' ',
+    folder = ' ',
+    lines = ' ',
   }
 
   return M

--- a/lua/slimline/default_config.lua
+++ b/lua/slimline/default_config.lua
@@ -1,21 +1,41 @@
-local M = {
-  bold = false,
-  verbose_mode = false,
-  style = 'bg',
-  spaces = {
+local function create_M()
+  local M = {}
+
+  M.bold = false
+  M.verbose_mode = false
+  M.style = 'bg'
+
+  M.spaces = {
     components = ' ',
     left = ' ',
     right = ' ',
-  },
-  sep = {
+  }
+
+  M.sep = {
     hide = {
       first = false,
       last = false,
     },
     left = '',
     right = '',
-  },
-  hl = {
+  }
+
+  M.components = {
+    'mode',
+    M.spaces.components,
+    'path',
+    M.spaces.components,
+    'git',
+    '%=',
+    'diagnostics',
+    M.spaces.components,
+    'filetype_lsp',
+    M.spaces.components,
+    'progress',
+    M.spaces.right,
+  }
+
+  M.hl = {
     modes = {
       normal = 'Type',
       insert = 'Function',
@@ -26,20 +46,25 @@ local M = {
     base = 'Comment',
     primary = 'Normal',
     secondary = 'Comment',
-  },
-  icons = {
+  }
+
+  M.icons = {
     diagnostics = {
-      ERROR = ' ',
-      WARN = ' ',
-      HINT = ' ',
-      INFO = ' ',
+      ERROR = ' ',
+      WARN = ' ',
+      HINT = ' ',
+      INFO = ' ',
     },
     git = {
-      branch = '',
+      branch = '',
     },
-    folder = ' ',
-    lines = ' ',
-  },
-}
+    folder = ' ',
+    lines = ' ',
+  }
+
+  return M
+end
+
+local M = create_M()
 
 return M

--- a/lua/slimline/highlights.lua
+++ b/lua/slimline/highlights.lua
@@ -1,5 +1,3 @@
-local config = vim.g.slimline_config
-
 local M = {}
 
 M.hls = {
@@ -36,8 +34,8 @@ M.hls = {
     },
   },
 }
-
-function M.create()
+---@param config table
+function M.create(config)
   M.hls.base = M.get_or_create('', config.hl.base)
 
   local as_background = true

--- a/lua/slimline/init.lua
+++ b/lua/slimline/init.lua
@@ -1,17 +1,30 @@
 local M = {}
 local components = require('slimline.components')
+local components_length = 0
+local position = 0
 
 --- Returns correct component from config
 ---@return function
 ---@param component_name string | function
 ---@param config table
 local function resolve_component(component_name, config)
+  position = position + 1
   if type(component_name) == 'function' then
     return component_name
   elseif type(component_name) == 'string' then
     if components[component_name] then
+      local sep = {
+        left = config.sep.left,
+        right = config.sep.right,
+      }
+      if config.sep.hide.first and position == 1 then
+        sep.left = ''
+      end
+      if config.sep.hide.last and position == components_length then
+        sep.right = ''
+      end
       return function(...)
-        return components[component_name](config, ...)
+        return components[component_name](config, sep, ...)
       end
     else
       return function()
@@ -91,8 +104,11 @@ function M.setup(opts)
     opts.sep.right = ''
   end
 
+  components_length = #opts.components.left + #opts.components.center + #opts.components.right
+
   -- Resolve component references
   opts.components.left = resolve_components(opts.components.left, opts)
+  opts.components.center = resolve_components(opts.components.center, opts)
   opts.components.right = resolve_components(opts.components.right, opts)
 
   vim.g.slimline_config = opts


### PR DESCRIPTION
This PR attempts to add some configurability to the statusline.

In addition to being able to choose the order in which components are displayed, it makes custom components possible by allowing functions in the config.

As an example, adding your own git blame text.
```lua
components = {
	"mode",
	" ",
	"path",
	" ",
	"git",
	"%=",
	function()
	  local git_blame = require("gitblame")
	  if git_blame.is_blame_text_available() then
            return git_blame.get_current_blame_text()
	  else
            return ""
	  end
	end,
	"%=",
	"diagnostics",
	" ",
	"filetype_lsp",
	" ",
	"progress",
	" ",
},
```



I'm happy to hear any notes/suggestions.

For example not quite happy with how seperators are now done in custom config.
Perhaps special string identifiers like `'spaces.left'` could be converted to the config value.

I don't want to intrude into your personal project, so feel free to just close my PR if that's the case!