### PR TITLE
corrected fallback for mode

### DIFF
--- a/lua/slimline/highlights.lua
+++ b/lua/slimline/highlights.lua
@@ -194,7 +194,7 @@ function M.get_mode_hl(mode)
   elseif mode:find('COMMAND') or mode:find('TERMINAL') or mode:find('EX') then
     return M.hls.mode.command
   end
-  return M.hls
+  return M.hls.mode.command
 end
 
 return M


### PR DESCRIPTION
For modes that are not present in user-selected highlight colors, an error is thrown, crashing the plugin. This PR corrects this issue by making the fallback hl the command mode (it would be possible to use other modes, but I chose command as it's the least common mode in the default config, which I think makes sense as the fallback would also be used for uncommon modes).