### PR TITLE
Add support for workspace diagnostics

### DIFF
--- a/lua/slimline/components/diagnostics.lua
+++ b/lua/slimline/components/diagnostics.lua
@@ -24,7 +24,13 @@ function M.render(sep, direction)
     return last_diagnostic_component
   end
 
-  local counts = vim.iter(vim.diagnostic.get(0)):fold({
+  local buffer
+  if config.workspace_diagnostics then
+    buffer = nil
+  else
+    buffer = 0
+  end
+  local counts = vim.iter(vim.diagnostic.get(buffer)):fold({
     ERROR = 0,
     WARN = 0,
     HINT = 0,

--- a/lua/slimline/default_config.lua
+++ b/lua/slimline/default_config.lua
@@ -3,6 +3,7 @@ local M = {
   verbose_mode = false, -- Mode as single letter or as a word
   style = 'bg', -- or "fg". Whether highlights should be applied to bg or fg of components
   mode_follow_style = true, -- Whether the mode color components should follow the style option
+  workspace_diagnostics = false, -- Whether diagnostics should show workspace diagnostics instead of current buffer
   components = { -- Choose components and their location
     left = {
       'mode',


### PR DESCRIPTION
Add the ability to choose between diagnostics for only the current buffer or for full workspace diagnostics. Retains diagnostics for only the current buffer as the default.