### PR TITLE
fix: diagnostic highlights when DiagnosticVirtualText* has no bg

### DIFF
--- a/lua/slimline/components/diagnostics.lua
+++ b/lua/slimline/components/diagnostics.lua
@@ -61,7 +61,7 @@ function M.render(sep, direction, _)
       end
       return highlights.hl_component({ primary = string.format('%s%d', icons[severity], count) }, {
         primary = {
-          text = 'DiagnosticVirtualText' .. capitalize(severity),
+          text = 'SlimlineDiagnosticVirtualText' .. capitalize(severity),
         },
       }, sep, direction)
     end)


### PR DESCRIPTION
- Established `diagostics` highlighting in `style: bg` when `DiagnosticVirtualText*` highlight groups do not have a background
- Linking highlight groups when possible
- Made highlight creating more stable following `link` highlight groups