### PR TITLE
feat: path directory truncating

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## Next
+
+### Added
+
+- `path`: fish like `truncate`. Enabled by default with `chars = 1` and `full_dirs = 2`
+
 ## [2.1.0] - 2025-06-29
 
 ### Added
@@ -115,7 +121,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - Added component configuration table `configs` to configure style and features of components.
-
   - `verbose_mode` -> `configs.mode.verbose`
   - `mode_follow_style` -> `configs.mode.style`
   - `workspace_diagnostics` -> `configs.diagnostics.workspace`

--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ Here are some screenshots that might be a bit outdated. See [recipes](#recipes) 
 Available components:
 
 - `mode`, well, you know what it is. Automatically sets `vim.opt.showmode = false`.
-- `path`, shows the filename and the relative path + modified / read-only info
+- `path`, shows the filename and the relative path + modified / read-only info. The directory path will be truncated. Can be disabled and configured.
 - `git`, shows the git branch + file diff infos (added, modified and removed lines) (requires [gitsigns](https://github.com/lewis6991/gitsigns.nvim))
 - `diagnostics`, shows `vim.diagnostic` infos. This component is event driven and will not poll the information on every statusline draw.
 - `filetype_lsp`, shows the filetype and attached LSPs. Attached LSPs are evaluated event driven on LSP attach / detach events.
@@ -147,6 +147,11 @@ require('slimline').setup {
     },
     path = {
       directory = true, -- Whether to show the directory
+      -- truncates the directory path. Can be disabled by setting `truncate = false`
+      truncate = {
+        chars = 1, -- number of characters for each path component
+        full_dirs = 2, -- how many path components to keep unshortened
+      },
       icons = {
         folder = ' ',
         modified = '',

--- a/lua/slimline/components/path.lua
+++ b/lua/slimline/components/path.lua
@@ -3,6 +3,32 @@ local C = {}
 
 local config = slimline.config.configs.path
 
+---@param path string
+---@param chars integer
+---@param full_dirs integer
+---@return string
+local function truncate(path, chars, full_dirs)
+  local parts = {}
+  for part in path:gmatch('[^/]+') do
+    table.insert(parts, part)
+  end
+
+  local truncated = {}
+  local n_parts = #parts
+
+  for i, component in ipairs(parts) do
+    if i > (n_parts - full_dirs) then
+      table.insert(truncated, component)
+    elseif #component > chars then
+      table.insert(truncated, component:sub(1, chars))
+    else
+      table.insert(truncated, component)
+    end
+  end
+
+  return table.concat(truncated, '/')
+end
+
 --- @param sep {left: string, right: string}
 --- @param direction string
 --- |'"right"'
@@ -34,6 +60,9 @@ function C.render(sep, direction, hls, active)
     if path == '.' then
       path = ''
     else
+      if config.truncate then
+        path = truncate(path, config.truncate.chars, config.truncate.full_dirs)
+      end
       path = config.icons.folder .. path
     end
   end

--- a/lua/slimline/defaults.lua
+++ b/lua/slimline/defaults.lua
@@ -39,6 +39,10 @@ local M = {
     },
     path = {
       directory = true, -- Whether to show the directory
+      truncate = {
+        chars = 1,
+        full_dirs = 2,
+      },
       icons = {
         folder = ' ',
         modified = '',


### PR DESCRIPTION
Usually one is not interested in every component of the directory path in the current buffer.

Truncates the directory of the `path` component inspired by fish's [prompt_pwd](https://fishshell.com/docs/current/cmds/prompt_pwd.html)