### PR TITLE
feat: support alternative git sources

### DIFF
--- a/lua/slimline/components/git.lua
+++ b/lua/slimline/components/git.lua
@@ -2,30 +2,52 @@ local C = {}
 
 local slimline = require('slimline')
 
+local function get_branch_from_git()
+  local handle = io.popen('git rev-parse --abbrev-ref HEAD 2>/dev/null')
+  if not handle then return '' end
+  local branch = handle:read('*a'):gsub('\n', '') or ''
+  handle:close()
+  return branch
+end
+
 ---@param opts render.options
 ---@return string
 function C.render(opts)
-  local status = vim.b.gitsigns_status_dict
-  if not status then return '' end
-  if not status.head or status.head == '' then return '' end
+  local gitsigns = vim.b.gitsigns_status_dict
+  local minidiff = vim.b.minidiff_summary
+
+  local branch = ''
+  if gitsigns and gitsigns.head and gitsigns.head ~= '' then
+    branch = gitsigns.head
+  else
+    branch = get_branch_from_git()
+  end
+
+  if not branch or branch == '' then return '' end
 
   local icons = slimline.config.configs['git'].icons
 
-  local branch = string.format('%s %s', icons.branch, status.head)
+  local branch_display = string.format('%s %s', icons.branch, branch)
 
-  local added = status.added and status.added > 0
-  local removed = status.removed and status.removed > 0
-  local changed = status.changed and status.changed > 0
-  local modifications = added or removed or changed
+  local status = { added = 0, removed = 0, changed = 0 }
+
+  if gitsigns and gitsigns.head and gitsigns.head ~= '' then
+    status.added = gitsigns.added or 0
+    status.removed = gitsigns.removed or 0
+    status.changed = gitsigns.changed or 0
+  elseif minidiff and minidiff.source_name and minidiff.source_name ~= '' then
+    status.added = minidiff.add or 0
+    status.removed = minidiff.delete or 0
+    status.changed = minidiff.change or 0
+  end
 
   local mods = {}
-  if modifications then
-    if added then table.insert(mods, string.format('%s%s', icons.added, status.added)) end
-    if changed then table.insert(mods, string.format('%s%s', icons.modified, status.changed)) end
-    if removed then table.insert(mods, string.format('%s%s', icons.removed, status.removed)) end
-  end
+  if status.added > 0 then table.insert(mods, string.format('%s%s', icons.added, status.added)) end
+  if status.changed > 0 then table.insert(mods, string.format('%s%s', icons.modified, status.changed)) end
+  if status.removed > 0 then table.insert(mods, string.format('%s%s', icons.removed, status.removed)) end
+
   return slimline.highlights.hl_component(
-    { primary = branch, secondary = table.concat(mods, ' ') },
+    { primary = branch_display, secondary = #mods > 0 and table.concat(mods, ' ') or '' },
     opts.hls,
     opts.sep,
     opts.direction,

--- a/lua/slimline/components/git.lua
+++ b/lua/slimline/components/git.lua
@@ -16,7 +16,7 @@ function C.render(opts)
   local gitsigns = vim.b.gitsigns_status_dict
   local minidiff = vim.b.minidiff_summary
 
-  local branch = ''
+  local branch
   if gitsigns and gitsigns.head and gitsigns.head ~= '' then
     branch = gitsigns.head
   elseif vim.fn.exists('*FugitiveHead') == 1 then

--- a/lua/slimline/components/git.lua
+++ b/lua/slimline/components/git.lua
@@ -19,6 +19,8 @@ function C.render(opts)
   local branch = ''
   if gitsigns and gitsigns.head and gitsigns.head ~= '' then
     branch = gitsigns.head
+  elseif vim.fn.exists('*FugitiveHead') == 1 then
+    branch = vim.fn['FugitiveHead']()
   else
     branch = get_branch_from_git()
   end


### PR DESCRIPTION
This pull request adds support for other git plugins in addition to the existing gitsigns. Currently, gitsigns handles both the head and modifications. The other integrations are not as complete in functionality so we combine multiple methods:

**Head:** gitsigns.nvim &rarr; vim-fugitive &rarr; git cli
**Mods:** gitsigns.nvim &rarr; mini.diff

You may notice fugitive _only_ handles getting the branch. This _is_ an improvement over the git cli, though, as it respects the current directory. For example:

**vim-fugitive**

```sh
cd my-project
nvim
# => main branch
nvim ~/.config/nvim/init.lua
# => no branch
```

**git cli**

```sh
cd my-project
nvim
# => main branch
nvim ~/.config/nvim/init.lua
# => main branch
```

If this feature is welcome, I can update the README as part of this PR or as a separate PR (unless you'd prefer using your own wording). Let me know :)