### PR TITLE
fix: streamlined diagnostic hls

### DIFF
--- a/README.md
+++ b/README.md
@@ -205,6 +205,12 @@ By default, all `components` will be shown. Inactive components will use the _se
         HINT = ' ',
         INFO = ' ',
       },
+      hl = {
+        error = 'DiagnosticError',
+        warn = 'DiagnosticWarn',
+        hint = 'DiagnosticHint',
+        info = 'DiagnosticInfo',
+      },
     },
     filetype_lsp = {
       trunc_width = 95,
@@ -348,14 +354,14 @@ Make sure to do that **before** slimline's `setup()`.
 | SlimlineSelectioncountPrimarySep2Sec | Selectioncount primary separator to secondary                                                    |
 | SlimlineSelectioncountSecondary      | Selectioncount secondary                                                                         |
 | SlimlineSelectioncountSecondarySep   | Selectioncount secondary separator                                                               |
-| SlimlineDiagnosticHint               | Diagnostic hints                                                                                 |
-| SlimlineDiagnosticInfo               | Diagnostic infos                                                                                 |
-| SlimlineDiagnosticWarn               | Diagnostic warnings                                                                              |
-| SlimlineDiagnosticError              | Diagnostic errors                                                                                |
-| SlimlineDiagnosticVirtualTextHint    | Diagnostic hints (for `style = bg` only)                                                         |
-| SlimlineDiagnosticVirtualTextInfo    | Diagnostic infos (for `style = bg` only)                                                         |
-| SlimlineDiagnosticVirtualTextWarn    | Diagnostic warnings (for `style = bg` only)                                                      |
-| SlimlineDiagnosticVirtualTextError   | Diagnostic errors (for `style = bg` only)                                                        |
+| SlimlineDiagnosticsHint              | Diagnostic hints                                                                                 |
+| SlimlineDiagnosticsHintSep           | Diagnostic hints sep                                                                             |
+| SlimlineDiagnosticsInfo              | Diagnostic infos                                                                                 |
+| SlimlineDiagnosticsInfoSep           | Diagnostic infos sep                                                                             |
+| SlimlineDiagnosticsWarn              | Diagnostic warnings                                                                              |
+| SlimlineDiagnosticsWarnSep           | Diagnostic warnings sep                                                                          |
+| SlimlineDiagnosticsError             | Diagnostic errors                                                                                |
+| SlimlineDiagnosticsErrorSep          | Diagnostic errors sep                                                                            |
 
 </details>
 

--- a/lua/slimline/components/diagnostics.lua
+++ b/lua/slimline/components/diagnostics.lua
@@ -54,52 +54,41 @@ local function format(buffer, workspace)
     local wc = workspace[severity]
     if wc > 0 or bc > 0 then
       local count = get_count_format(bc, wc)
-      if style == 'fg' then
-        local hl = 'SlimlineDiagnostic' .. capitalize(severity)
-        table.insert(parts_active, string.format('%%#%s#%s%s', hl, icons[severity], count))
-        table.insert(parts_inactive, string.format('%%#%s#%s%s', 'SlimlineDiagnosticSecondary', icons[severity], count))
-      else
-        local hls = {
-          primary = {
-            text = 'SlimlineDiagnosticVirtualText' .. capsev,
-            sep = 'SlimlineDiagnosticVirtualText' .. capsev .. 'Sep',
-          },
-          secondary = {
-            text = 'SlimlineDiagnosticsSecondary',
-            sep = 'SlimlineDiagnosticsSecondarySep',
-          },
-        }
-        table.insert(
-          parts_active,
-          slimline.highlights.hl_component(
-            { primary = string.format('%s%s', icons[severity], count) },
-            hls,
-            sep_,
-            direction_,
-            true
-          )
+      local hls = {
+        primary = {
+          text = 'SlimlineDiagnostics' .. capsev,
+          sep = 'SlimlineDiagnostics' .. capsev .. 'Sep',
+        },
+        secondary = {
+          text = 'SlimlineDiagnosticsSecondary',
+          sep = 'SlimlineDiagnosticsSecondarySep',
+        },
+      }
+      table.insert(
+        parts_active,
+        slimline.highlights.hl_component(
+          { primary = string.format('%s%s', icons[severity], count) },
+          hls,
+          sep_,
+          direction_,
+          true
         )
-        table.insert(
-          parts_inactive,
-          slimline.highlights.hl_component(
-            { primary = string.format('%s%s', icons[severity], count) },
-            hls,
-            sep_,
-            direction_,
-            false
-          )
+      )
+      table.insert(
+        parts_inactive,
+        slimline.highlights.hl_component(
+          { primary = string.format('%s%s', icons[severity], count) },
+          hls,
+          sep_,
+          direction_,
+          false
         )
-      end
+      )
     end
   end
 
-  local hl_reset = string.format('%%#%s#', slimline.highlights.hls.base)
-
-  if #parts_active > 0 then table.insert(parts_active, hl_reset) end
-  if #parts_inactive > 0 then table.insert(parts_inactive, hl_reset) end
-
   local sep = slimline.config.spaces.components
-  if style == 'fg' then sep = ' ' end
+  if style == 'fg' then sep = '' end
 
   return { active = table.concat(parts_active, sep), inactive = table.concat(parts_inactive, sep) }
 end

--- a/lua/slimline/defaults.lua
+++ b/lua/slimline/defaults.lua
@@ -87,6 +87,12 @@ local M = {
         HINT = ' ',
         INFO = ' ',
       },
+      hl = {
+        error = 'DiagnosticError',
+        warn = 'DiagnosticWarn',
+        hint = 'DiagnosticHint',
+        info = 'DiagnosticInfo',
+      },
     },
     filetype_lsp = {
       trunc_width = 95,

--- a/lua/slimline/highlights.lua
+++ b/lua/slimline/highlights.lua
@@ -76,44 +76,6 @@ local function create(hl, base, inverse, bold, bg_from_fg, bg_from_bg)
   return hl
 end
 
-local function create_diagnostic_highlights()
-  local slimline = require('slimline')
-  local style = slimline.config.configs.diagnostics.style or slimline.config.style
-
-  --- Make sure that Diagnostic* hl groups have base as background
-  create('DiagnosticHint', 'DiagnosticHint', false, false, nil, M.hls.base)
-  create('DiagnosticInfo', 'DiagnosticInfo', false, false, nil, M.hls.base)
-  create('DiagnosticWarn', 'DiagnosticWarn', false, false, nil, M.hls.base)
-  create('DiagnosticError', 'DiagnosticError', false, false, nil, M.hls.base)
-
-  if style == 'bg' then
-    local dv_bg = vim.api.nvim_get_hl(0, { name = 'DiagnosticVirtualTextError', link = false }).bg
-    if dv_bg == nil then
-      create('DiagnosticVirtualTextHint', 'SlimlineDiagnosticHint', true, false, nil, nil)
-      create('DiagnosticVirtualTextInfo', 'SlimlineDiagnosticInfo', true, false, nil, nil)
-      create('DiagnosticVirtualTextWarn', 'SlimlineDiagnosticWarn', true, false, nil, nil)
-      create('DiagnosticVirtualTextError', 'SlimlineDiagnosticError', true, false, nil, nil)
-    else
-      create('DiagnosticVirtualTextHint', 'DiagnosticVirtualTextHint', false, false, nil, nil)
-      create('DiagnosticVirtualTextInfo', 'DiagnosticVirtualTextInfo', false, false, nil, nil)
-      create('DiagnosticVirtualTextWarn', 'DiagnosticVirtualTextWarn', false, false, nil, nil)
-      create('DiagnosticVirtualTextError', 'DiagnosticVirtualTextError', false, false, nil, nil)
-    end
-
-    --- Create Diagnostic Seps for bg mode
-    local bg = vim.api.nvim_get_hl(0, { name = M.hls.base, link = false }).bg
-    local fg
-    fg = vim.api.nvim_get_hl(0, { name = 'SlimlineDiagnosticVirtualTextError', link = false }).bg
-    vim.api.nvim_set_hl(0, 'SlimlineDiagnosticVirtualTextErrorSep', { bg = bg, fg = fg })
-    fg = vim.api.nvim_get_hl(0, { name = 'SlimlineDiagnosticVirtualTextWarn', link = false }).bg
-    vim.api.nvim_set_hl(0, 'SlimlineDiagnosticVirtualTextWarnSep', { bg = bg, fg = fg })
-    fg = vim.api.nvim_get_hl(0, { name = 'SlimlineDiagnosticVirtualTextInfo', link = false }).bg
-    vim.api.nvim_set_hl(0, 'SlimlineDiagnosticVirtualTextInfoSep', { bg = bg, fg = fg })
-    fg = vim.api.nvim_get_hl(0, { name = 'SlimlineDiagnosticVirtualTextHint', link = false }).bg
-    vim.api.nvim_set_hl(0, 'SlimlineDiagnosticVirtualTextHintSep', { bg = bg, fg = fg })
-  end
-end
-
 function M.create()
   if not M.initialized then return end
 
@@ -201,7 +163,14 @@ function M.create()
         }
       else
         if component == 'diagnostics' then
-          create_diagnostic_highlights()
+          create(prefix .. 'Error', component_config.hl.error, inverse, false, nil, M.hls.base)
+          create(prefix .. 'ErrorSep', component_config.hl.error, false, false, nil, M.hls.base)
+          create(prefix .. 'Warn', component_config.hl.warn, inverse, false, nil, M.hls.base)
+          create(prefix .. 'WarnSep', component_config.hl.warn, false, false, nil, M.hls.base)
+          create(prefix .. 'Info', component_config.hl.info, inverse, false, nil, M.hls.base)
+          create(prefix .. 'InfoSep', component_config.hl.infoo, false, false, nil, M.hls.base)
+          create(prefix .. 'Hint', component_config.hl.hint, inverse, false, nil, M.hls.base)
+          create(prefix .. 'HintSep', component_config.hl.hint, false, false, nil, M.hls.base)
           create(prefix .. 'Secondary', secondary, inverse, false, nil, M.hls.base)
           create(prefix .. 'SecondarySep', secondary, false, false, nil, M.hls.base)
         else


### PR DESCRIPTION
I was not happy with diagnostic highlights and the implicit behavior of virtual text highlight groups.
Also with how it looked when diagnostic section goes inactive and having virtual text highlight groups.

Instead, using `Diagnostic*`  highlight groups only, which is more consistent with how the rest looks.
Also makes the code simpler