### PR TITLE
dfix: made fg component more compact

### DIFF
--- a/README.md
+++ b/README.md
@@ -533,7 +533,8 @@ function(active)
         Slimline.highlights.hls.components['path'],
         Slimline.get_sep('path'),
         'right', -- flow direction (on which side the secondary part will be rendered)
-        active -- whether the component is active or not
+        active, -- whether the component is active or not
+        'fg' -- style to use
     )
 end,
 ```

--- a/lua/slimline/components/diagnostics.lua
+++ b/lua/slimline/components/diagnostics.lua
@@ -71,7 +71,8 @@ local function format(buffer, workspace)
           hls,
           sep_,
           direction_,
-          true
+          true,
+          style
         )
       )
       table.insert(
@@ -81,7 +82,8 @@ local function format(buffer, workspace)
           hls,
           sep_,
           direction_,
-          false
+          false,
+          style
         )
       )
     end

--- a/lua/slimline/components/filetype_lsp.lua
+++ b/lua/slimline/components/filetype_lsp.lua
@@ -56,7 +56,8 @@ function C.render(opts)
     opts.hls,
     opts.sep,
     opts.direction,
-    opts.active
+    opts.active,
+    opts.style
   )
 end
 

--- a/lua/slimline/components/git.lua
+++ b/lua/slimline/components/git.lua
@@ -53,7 +53,8 @@ function C.render(opts)
     opts.hls,
     opts.sep,
     opts.direction,
-    opts.active
+    opts.active,
+    opts.style
   )
 end
 

--- a/lua/slimline/components/mode.lua
+++ b/lua/slimline/components/mode.lua
@@ -17,7 +17,7 @@ function C.render(opts)
   local mode = slimline.get_mode()
   local primary = mode.short
   if verbose then primary = mode.verbose end
-  return slimline.highlights.hl_component({ primary = primary }, opts.hls, opts.sep, opts.direction, opts.active)
+  return slimline.highlights.hl_component({ primary = primary }, opts.hls, opts.sep, opts.direction, opts.active, opts.style)
 end
 
 return C

--- a/lua/slimline/components/path.lua
+++ b/lua/slimline/components/path.lua
@@ -57,7 +57,8 @@ function C.render(opts)
     opts.hls,
     opts.sep,
     opts.direction,
-    opts.active
+    opts.active,
+    opts.style
   )
 end
 

--- a/lua/slimline/components/progress.lua
+++ b/lua/slimline/components/progress.lua
@@ -30,7 +30,8 @@ function C.render(opts)
     opts.hls,
     opts.sep,
     opts.direction,
-    opts.active
+    opts.active,
+    opts.style
   )
 end
 

--- a/lua/slimline/components/recording.lua
+++ b/lua/slimline/components/recording.lua
@@ -8,7 +8,7 @@ function C.render(opts)
   local recording = vim.fn.reg_recording()
   if recording == '' then return '' end
   local status = config.icon .. recording
-  return slimline.highlights.hl_component({ primary = status }, opts.hls, opts.sep, opts.direction, opts.active)
+  return slimline.highlights.hl_component({ primary = status }, opts.hls, opts.sep, opts.direction, opts.active, opts.style)
 end
 
 return C

--- a/lua/slimline/components/searchcount.lua
+++ b/lua/slimline/components/searchcount.lua
@@ -23,7 +23,8 @@ function C.render(opts)
     opts.hls,
     opts.sep,
     opts.direction,
-    opts.active
+    opts.active,
+    opts.style
   )
 end
 

--- a/lua/slimline/components/selectioncount.lua
+++ b/lua/slimline/components/selectioncount.lua
@@ -28,7 +28,8 @@ function C.render(opts)
     opts.hls,
     opts.sep,
     opts.direction,
-    opts.active
+    opts.active,
+    opts.style
   )
 end
 

--- a/lua/slimline/highlights.lua
+++ b/lua/slimline/highlights.lua
@@ -213,53 +213,67 @@ function M.hl_content(content, hl, sep)
   return rendered
 end
 
----@param content string?
----@return string?
-function M.pad(content)
-  if content == nil or content == '' then return content end
-  return ' ' .. content .. ' '
+---@param content {primary: string?, secondary: string?}
+---@param style component.style
+---@param direction component.direction?
+---@return {primary: string?, secondary: string?}
+function M.pad(content, style, direction)
+  content.primary = ' ' .. content.primary .. ' '
+
+  if content.secondary and content.secondary ~= '' then
+    if style == 'bg' then
+      content.secondary = ' ' .. content.secondary .. ' '
+    else
+      if direction == 'right' then
+        content.secondary = content.secondary .. ' '
+      else
+        content.secondary = ' ' .. content.secondary
+      end
+    end
+  end
+
+  return content
 end
 
----@param content {primary: string, secondary: string?}
+---@param content {primary: string?, secondary: string?}
 ---@param hl component.highlights
 ---@param sep sep
 ---@param direction component.direction?
 ---@param active boolean
+---@param style component.style
 ---@return string
-function M.hl_component(content, hl, sep, direction, active)
+function M.hl_component(content, hl, sep, direction, active, style)
   active = active == nil or active
   local result
-  if content.primary == nil then return '' end
+  if content.primary == nil or content.primary == '' then return '' end
+
+  content = M.pad(content, style, direction)
 
   if content.secondary == nil then
     if active then
-      result = M.hl_content(M.pad(content.primary), hl.primary, sep)
+      result = M.hl_content(content.primary, hl.primary, sep)
     else
-      result = M.hl_content(M.pad(content.primary), hl.secondary, sep)
+      result = M.hl_content(content.primary, hl.secondary, sep)
     end
   else
     if direction == 'left' then
-      result = M.hl_content(M.pad(content.secondary), hl.secondary, { left = sep.left })
+      result = M.hl_content(content.secondary, hl.secondary, { left = sep.left })
       if active then
         result = result .. M.hl_content(sep.left, { text = hl.primary.sep2sec }, {})
-        result = result .. M.hl_content(M.pad(content.primary), hl.primary, { right = sep.right })
+        result = result .. M.hl_content(content.primary, hl.primary, { right = sep.right })
       else
-        local fill = ' '
-        if sep.left == '' and sep.right == '' then fill = '' end
-        result = result .. M.hl_content(fill, { text = hl.secondary.text }, {})
-        result = result .. M.hl_content(M.pad(content.primary), hl.secondary, { right = sep.right })
+        if sep.left ~= '' then content.primary = ' ' .. content.primary end
+        result = result .. M.hl_content(content.primary, hl.secondary, { right = sep.right })
       end
     else
       if active then
-        result = M.hl_content(M.pad(content.primary), hl.primary, { left = sep.left })
+        result = M.hl_content(content.primary, hl.primary, { left = sep.left })
         result = result .. M.hl_content(sep.right, { text = hl.primary.sep2sec }, {})
       else
-        local fill = ' '
-        if sep.left == '' and sep.right == '' then fill = '' end
-        result = M.hl_content(M.pad(content.primary), hl.secondary, { left = sep.left })
-        result = result .. M.hl_content(fill, { text = hl.secondary.text }, {})
+        if sep.right ~= '' then content.primary = content.primary .. ' ' end
+        result = M.hl_content(content.primary, hl.secondary, { left = sep.left })
       end
-      result = result .. M.hl_content(M.pad(content.secondary), hl.secondary, { right = sep.right })
+      result = result .. M.hl_content(content.secondary, hl.secondary, { right = sep.right })
     end
   end
   result = result .. '%#' .. M.hls.base .. '#'

--- a/lua/slimline/init.lua
+++ b/lua/slimline/init.lua
@@ -17,6 +17,10 @@ Slimline.highlights = require('slimline.highlights')
 ---|'"first"'
 ---|'"last"'
 
+---@alias component.style string
+---|'"fg"'
+---|'"bg"'
+
 ---@alias group_position string
 ---|'"left"'
 ---|'"center"'
@@ -37,6 +41,7 @@ Slimline.highlights = require('slimline.highlights')
 ---@field direction component.direction
 ---@field sep sep
 ---@field hls component.highlights
+---@field style component.style
 
 ---@type components
 Slimline.active = vim.defaulttable()
@@ -115,7 +120,9 @@ local function get_component(component_ref, position, direction)
   elseif type(component_ref) == 'string' then
     local ok, cmp = pcall(require, string.format('slimline.components.%s', component_ref))
     if ok then
-      local follow = Slimline.config.configs[component_ref].follow
+      local cfg = Slimline.config.configs[component_ref]
+      local follow = cfg.follow
+      local style = (cfg and cfg.style) or Slimline.config.style
       local sep = Slimline.get_sep(follow or component_ref)
       if Slimline.config.sep.hide.first and position == 'first' then sep.left = '' end
       if Slimline.config.sep.hide.last and position == 'last' then sep.right = '' end
@@ -124,7 +131,7 @@ local function get_component(component_ref, position, direction)
         render = function(active)
           local hls = Slimline.highlights.hls.components[follow or component_ref]
           if component_ref == 'mode' or follow == 'mode' then hls = Slimline.get_mode().hls end
-          return cmp.render({ sep = sep, direction = direction, hls = hls, active = active })
+          return cmp.render({ sep = sep, direction = direction, hls = hls, active = active, style = style })
         end,
       }
     else


### PR DESCRIPTION
The primary and secondary part of a component always was padded with surrounding spaces.
This leads to unnecessary space when the component is in **fg** mode.
Making the pad function aware of the style and therefore only having one space when in **fg** mode.
Makes the line more compact.

With this change, the most compact line you can get is using `style="fg"` combined with `spaces.components=''`.
Components will then be spaced by **2** spaces since a component naturally gets padded on the outside with one empty space.